### PR TITLE
fixes node deletion so that store updates properly progagate to node components

### DIFF
--- a/src/lib/models/TemporaryEdge.ts
+++ b/src/lib/models/TemporaryEdge.ts
@@ -14,8 +14,10 @@ import { stores } from './store';
 export class TemporaryEdge implements TemporaryEdgeType {
   constructor(
     public id: string,
+    public sourceNodeId: string, // this will always be set
     public sourceX: number,
     public sourceY: number,
+    public targetNodeId: string | null, // this will be null until the temporary edge reaches another temporary anchor
     public targetX: number,
     public targetY: number,
     public canvasId: string,

--- a/src/lib/views/Edges/PotentialAnchor.svelte
+++ b/src/lib/views/Edges/PotentialAnchor.svelte
@@ -1,11 +1,21 @@
-<script>
+<script lang="ts">
   import { getNodes, getAnchors, findStore } from '$lib/controllers/storeApi';
   import { TemporaryEdge } from '$lib/models/TemporaryEdge';
-
+  import type {
+    NodeType,
+    EdgeType,
+    AnchorType,
+    StoreType,
+    UserNodeType,
+    UserEdgeType,
+    TemporaryEdgeType,
+    PotentialAnchorType,
+  } from '$lib/models/types';
   import { beforeUpdate, afterUpdate } from 'svelte';
   export let canvasId;
   export let x;
   export let y;
+  export let potentialAnchor: PotentialAnchorType;
 
   let newEdge;
   let hovered = false;
@@ -32,8 +42,10 @@
         if (edges.length === 0) {
           const newTempEdge = new TemporaryEdge(
             uuidv4(),
+            potentialAnchor.nodeId,
             mouseX,
             mouseY,
+            null,
             mouseX,
             mouseY,
             canvasId,

--- a/src/lib/views/Edges/TemporaryEdge.svelte
+++ b/src/lib/views/Edges/TemporaryEdge.svelte
@@ -3,7 +3,6 @@
   let path = '';
   $: {
     path = `M ${temporaryEdge.sourceX},${temporaryEdge.sourceY}L ${temporaryEdge.targetX},${temporaryEdge.targetY}`;
-    // console.log(temporaryEdge);
   }
 </script>
 

--- a/src/lib/views/RefactoredComponents/GraphView.svelte
+++ b/src/lib/views/RefactoredComponents/GraphView.svelte
@@ -131,6 +131,7 @@
         {canvasId}
         x={potentialAnchor.positionX}
         y={potentialAnchor.positionY}
+        {potentialAnchor}
       />
     {/each}
   </div>


### PR DESCRIPTION
Also implements node deletion cascading to anchor deletion, edge deletion.
node deletion cascading to potentialAnchor, resizeNode not yet implemented

Something interesting: it looks like Svelte's templating system {#each nodeSore as node /} does not play well with objects. In terms of patterns/antipatterns maybe: 